### PR TITLE
Sys georef

### DIFF
--- a/apply_acv.py
+++ b/apply_acv.py
@@ -51,12 +51,12 @@ def read_args():
         help="Jpeg compression quality (default: 100, no compression)",
     )
     parser.add_argument("-v", "--verbose", help="verbose (default: 0)", type=int, default=0)
-    args = parser.parse_args()
+    args_apply_acv = parser.parse_args()
 
-    if args.verbose >= 1:
-        print("\nArguments: ", args)
+    if args_apply_acv.verbose >= 1:
+        print("\nArguments: ", args_apply_acv)
 
-    return args
+    return args_apply_acv
 
 
 def load_acv(nom):
@@ -183,7 +183,7 @@ def preparation(a_line):
     return courbes
 
 
-ARGS = read_args()
+args = read_args()
 
 dir_acv = os.path.splitext(ARGS.acv)[0]
 id_image = ARGS.curve.split(",")[0]
@@ -191,11 +191,22 @@ nom_img = os.path.join(ARGS.input, id_image)
 
 IMAGE = gdal.Open(nom_img)
 geo_trans = IMAGE.GetGeoTransform()
+projection = IMAGE.GetSpatialRef()
+print(f"Projection = {projection}")
 OUTPUT = gdal.GetDriverByName("MEM").Create(
     "", IMAGE.RasterXSize, IMAGE.RasterYSize, IMAGE.RasterCount, gdal.GDT_Byte
 )
+
 if geo_trans and geo_trans != (0.0, 1.0, 0.0, 0.0, 0.0, 1.0):
     OUTPUT.SetGeoTransform(geo_trans)
+
+# on impose la projection
+if args.projection:
+    OUTPUT.SetProjection(f"EPSG:{args.projection}")
+#if projection: (on recupere la projection des donnees en entree)
+#    OUTPUT.SetSpatialRef(projection)
+
+OUTPUT.SetProjection("EPSG:2154")
 
 COURBES = preparation(ARGS.curve)
 

--- a/create_cmd.py
+++ b/create_cmd.py
@@ -34,10 +34,8 @@ def read_args():
     )
     parser.add_argument(
         "-p",
-        "--proj",
-        required=False,
-        help="projection for output images (default : keep)",
-        default="keep"
+        "--projection",
+        help="EPSG code for output files projection (if needed)",
     )
     parser.add_argument(
         "-q",
@@ -57,6 +55,13 @@ def read_args():
 
 
 args = read_args()
+
+# verification de la validite de la projection demandee
+if args.projection:
+    if not args.projection.isdigit() or len(args.projection) < 4 or len(args.projection) > 5:
+        raise SystemExit('** ERREUR: '
+                         'La projection indiquee n\'est pas valable !'
+                         % args.projection)
 
 fOut = open(args.file, "w")
 
@@ -78,9 +83,6 @@ for line in f:
 for file in listFiles:
     tile = os.path.basename(file)
 
-    if args.proj == "keep":
-        print(f"On garde la projection initiale")
-
     if tile in listCurves:  # on fait des retouches sur l'image
         index = listCurves.index(tile)
         line = listCmd[index]
@@ -88,7 +90,7 @@ for file in listFiles:
         if not line.endswith('\n'):
             line = line + '\n'
 
-        fOut.write(
+        cmd_apply_acv = (
             "python "
             + pathApplyAcv
             + " -i "
@@ -101,19 +103,26 @@ for file in listFiles:
             + str(args.blocksize)
             + " -q "
             + str(args.quality)
+            + " -p "
+            + args.projection
             + " -c "
             + line
         )
+
+        fOut.write(cmd_apply_acv)
     else:  # pas de retouches a faire sur l'image
         if int(args.quality) < 100:
-            compress_param = " -co COMPRESS=JPEG -co QUALITY="+str(args.quality) + " "
+            gdal_param = " -co COMPRESS=JPEG -co QUALITY="+str(args.quality) + " "
         else:
-            compress_param = " -co COMPRESS=LZW "
+            gdal_param = " -co COMPRESS=LZW "
+
+        if args.projection:
+            gdal_param = "-a_srs EPSG:"+args.projection+" "
 
         fOut.write(
             "gdal_translate"
             + " -of COG -co BIGTIFF=YES "
-            + compress_param
+            + gdal_param
             + os.path.join(args.input, tile)
             + " "
             + os.path.join(args.output, tile)

--- a/create_cmd.py
+++ b/create_cmd.py
@@ -33,6 +33,13 @@ def read_args():
         default=1000
     )
     parser.add_argument(
+        "-p",
+        "--proj",
+        required=False,
+        help="projection for output images (default : keep)",
+        default="keep"
+    )
+    parser.add_argument(
         "-q",
         "--quality",
         help="JPEG compression quality (default: 90)",
@@ -70,6 +77,10 @@ for line in f:
 
 for file in listFiles:
     tile = os.path.basename(file)
+
+    if args.proj == "keep":
+        print(f"On garde la projection initiale")
+
     if tile in listCurves:  # on fait des retouches sur l'image
         index = listCurves.index(tile)
         line = listCmd[index]


### PR DESCRIPTION
Gérer correctement le système de projection des images : 
1/ Converser le système initial
2/ Imposer un système de projection pour les données en sortie

Correspond au ticket redmine 2011